### PR TITLE
Updated a label for Finnish/Swedish keyboard

### DIFF
--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -878,7 +878,7 @@ namespace SharpKeys
       m_hashKeys.Add("E0_53", "Special: Delete");
       m_hashKeys.Add("E0_54", "Unknown: 0xE054");
       m_hashKeys.Add("E0_55", "Unknown: 0xE055");
-      m_hashKeys.Add("E0_56", "Unknown: 0xE056");
+      m_hashKeys.Add("E0_56", "Key: < > |"); 
       m_hashKeys.Add("E0_57", "F-Lock: Save");        //   F11
       m_hashKeys.Add("E0_58", "F-Lock: Print");       //   F12
       m_hashKeys.Add("E0_59", "Unknown: 0xE059");

--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -878,7 +878,7 @@ namespace SharpKeys
       m_hashKeys.Add("E0_53", "Special: Delete");
       m_hashKeys.Add("E0_54", "Unknown: 0xE054");
       m_hashKeys.Add("E0_55", "Unknown: 0xE055");
-      m_hashKeys.Add("E0_56", "Key: < > |"); 
+      m_hashKeys.Add("E0_56", "Special: ISO extra key"); 
       m_hashKeys.Add("E0_57", "F-Lock: Save");        //   F11
       m_hashKeys.Add("E0_58", "F-Lock: Print");       //   F12
       m_hashKeys.Add("E0_59", "Unknown: 0xE059");


### PR DESCRIPTION
ISO keyboards have an extra button compared to ANSI keyboards. 
Added this extra button's label. 
This was requested in: https://github.com/randyrants/sharpkeys/issues/33