### PR TITLE
00_56 is the ISO additional key

### DIFF
--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -743,7 +743,7 @@ namespace SharpKeys
       m_hashKeys.Add("00_53", "Num: .");
       m_hashKeys.Add("00_54", "Unknown: 0x0054");
       m_hashKeys.Add("00_55", "Unknown: 0x0055");
-      m_hashKeys.Add("00_56", "Unknown: 0x0056");
+      m_hashKeys.Add("00_56", "Special: ISO extra key");
       m_hashKeys.Add("00_57", "Function: F11");
       m_hashKeys.Add("00_58", "Function: F12");
       m_hashKeys.Add("00_59", "Unknown: 0x0059");


### PR DESCRIPTION
ISO keyboards have one more key than ANSI keyboards (it sits to the immediate right of the left shift key).