### PR TITLE
Added manifest item to support HDPI monitors

### DIFF
--- a/SharpKeys/SharpKeys.exe.manifest
+++ b/SharpKeys/SharpKeys.exe.manifest
@@ -16,4 +16,15 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+    DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+    to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+    also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
 </assembly>


### PR DESCRIPTION
"dpiAware" will make SharpKeys really "sharp" on HDPI monitors
![sharpkeys](https://user-images.githubusercontent.com/275162/45476314-59aef780-b747-11e8-9777-2ed6d758809f.png)
