### PR TITLE
Add description for 'break' key

### DIFF
--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -1046,7 +1046,7 @@ namespace SharpKeys
             m_hashKeys.Add("E0_43", "F-Lock: Send");        //   F9
             m_hashKeys.Add("E0_44", "Unknown: 0xE044");
             m_hashKeys.Add("E0_45", "Special: €");        //   Euro
-            m_hashKeys.Add("E0_46", "Unknown: 0xE046");
+            m_hashKeys.Add("E0_46", "Special: Break");
             m_hashKeys.Add("E0_47", "Special: Home");
             m_hashKeys.Add("E0_48", "Arrow: Up");
             m_hashKeys.Add("E0_49", "Special: Page Up");


### PR DESCRIPTION
The `E0 46` scan code is used for the 'break' key. It is usually used
in combination with 'ctrl' to interrupt a console application.

Note that the 'pause' key, which 'break' usually shares a physical key
with on traditional 107-key keyboards, uses a different scan code. Those
keyboards would report report the `E0 46` scancode only when that
physical key is pressed together with 'ctrl' or 'shift'.