### PR TITLE
improve initial dialog, fix copyright date

### DIFF
--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -277,7 +277,7 @@ namespace SharpKeys
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(379, 17);
             this.label1.TabIndex = 9;
-            this.label1.Text = $"SharpKeys 3.9.0 - Copyright 2004 - {DateTime.Today.Year} RandyRants.com";
+            this.label1.Text = "COPYRIGHT MESSAGE";
             // 
             // label2
             // 
@@ -1127,6 +1127,8 @@ namespace SharpKeys
                 lvKeys.Items[0].Selected = true;
             }
             Cursor = Cursors.Default;
+
+            label1.Text = $"SharpKeys 3.9.0 - Copyright 2004 - {DateTime.Today.Year} RandyRants.com";
         }
 
         private void Dialog_Main_Closing(object sender, CancelEventArgs e)

--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -277,7 +277,7 @@ namespace SharpKeys
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(379, 17);
             this.label1.TabIndex = 9;
-            this.label1.Text = "SharpKeys 3.9.0 - Copyright 2004 - 2019 RandyRants.com";
+            this.label1.Text = $"SharpKeys 3.9.0 - Copyright 2004 - {DateTime.Today.Year} RandyRants.com";
             // 
             // label2
             // 

--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -453,7 +453,7 @@ namespace SharpKeys
 
             if (nWarning == 0)
             {
-                MessageBox.Show("Welcome to SharpKeys!\n\nThis application will add one key to your registry that allows you\nto change how certain keys on your keyboard will work.\n\nYou must be running Windows 2000 through Windows 10 for this to be supported and\nyou'll be using SharpKeys at your own risk!\n\nEnjoy!\nRandyRants.com", "SharpKeys");
+                MessageBox.Show("Welcome to SharpKeys!\n\nThis application will add one key to your registry that allows you\nto change how certain keys on your keyboard will work.\n\nYou must be running Windows 2000 through Windows 10 for this to be supported and you'll be using SharpKeys at your own risk!\n\nEnjoy!\nRandyRants.com", "SharpKeys");
             }
 
             // Set the WinPos


### PR DESCRIPTION
Remove the awkward line break which makes the current startup dialog look like this:
![image](https://user-images.githubusercontent.com/4165489/73129822-0a730b00-3fba-11ea-9643-18950ca512c9.png)
