### PR TITLE
Added support for apple right option key

### DIFF
--- a/SharpKeys/Dialog_Main.cs
+++ b/SharpKeys/Dialog_Main.cs
@@ -1180,7 +1180,9 @@ namespace SharpKeys
                                                         
             m_hashKeys.Add("E0_F1", "Special: Hanja Key");
             m_hashKeys.Add("E0_F2", "Special: Hangul Key");
-        }
+
+            m_hashKeys.Add("E0_2038", "Apple (Opt. Right)"); // Apple Option Right
+		}
 
         // Dialog related events and overrides
         private void Dialog_Main_Load(object sender, System.EventArgs e)


### PR DESCRIPTION
This PR adds support for the right option key on apple keyboards (sorry for the commit-message which says that it was the left option key) but this is for the right option key. Left was already supported.